### PR TITLE
Add mime-types

### DIFF
--- a/files/httpd_24.conf
+++ b/files/httpd_24.conf
@@ -282,7 +282,8 @@ LogLevel warn
     #
     AddType application/x-compress .Z
     AddType application/x-gzip .gz .tgz
-
+    AddType text/css .css
+    AddType text/javascript .js
     #
     # AddHandler allows you to map certain file extensions to "handlers":
     # actions unrelated to filetype. These can be either built into the server


### PR DESCRIPTION
this was needed for Hyku to render correctly. for some reason the css/js files would download, but only as text files, preventing the browser from actually _using_ them.