### PR TITLE
Include directive to disable HTTP TRACE command

### DIFF
--- a/files/httpd_24.conf
+++ b/files/httpd_24.conf
@@ -354,3 +354,6 @@ IncludeOptional conf.d/*.conf
 
 # Load virtual host files in the "/etc/httpd/vhosts.d" directory, if any.
 IncludeOptional vhosts.d/*.conf
+
+# Disable HTTP TRACE command
+TraceEnable off


### PR DESCRIPTION
Putting this in place to remediate vulnerability indicated in the campus IT security Qualys scans. 